### PR TITLE
docs: add developer flow documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS
+
+This repository contains a VSCode extension for remote development with DroidScript. See [how-it-works.md](./how-it-works.md) for full architectural details.
+
+## User-provided custom instructions
+- Follow any additional instructions provided directly by the user in task messages.
+
+## Codex Task Management
+
+### Vocabulary
+
+#### All code
+- The term "funcName()" is intended to disambiguate a function name from common terms. For example, "init()" or "the init() function" is used rather than "the init function", as the latter might be interpreted as any initialization function while the former is explicit about the function name.
+
+#### PHP
+- Various terms are used in instructions and in code comments, which are not found in code itself:
+- A reference to "SomeName::functionName" requires a lookup of `class SomeName` and `function functionName`. In many cases `class SomeName` will be found in a "somename.php" or "some-name.php" file, in WordPress\wp-content\plugins\nevenuti\src or a related subfolder.
+
+### Coding Conventions
+
+#### All code
+- Ensure code is modular, well-structured, and well-commented.
+- Ensure existing function docs are accurate. Add inline comments to code wherever it seems to help add clarity - document why code exists, not just how it does it.
+
+#### JavaScript / TypeScript
+- Use ESM, ES2022+ for NodeJS v22+ with JSDoc and TSDoc.
+- When diagnosing issues, search for possible issues with NodeJS, TypeScript, or NPM packages which are relevant to the problematic functionality.
+
+#### PHP
+- Use modern PHP 8.4 with PHPDoc, integrating with the WordPress 6.8+ API.
+- Use classes or traits to keep files and functions small and modular.
+- When diagnosing issues, search for related notes and nuances in the WordPress Codex, the WordPress core tracker, and the WordPress Gutenberg tracker.
+
+### README.md
+- The README.md file is not a changelog. README.md describes the project.
+- Do not look in README.md for guidance on how to proceed with your task.
+- Update README.md as required with new information about the existence of new features and how to use them.
+
+### Git
+- When creating a new branch always use a meaningful branch name that describes the task - don't use any text like "suggested-change" as part of the branch name or pull request text.
+
+### Special Task Instructions
+- If the user task message requests processing of a suggested change, open `SuggestedChanges.md` if it exists, process an Open item, and on successful completion move it to the Completed section.
+
+### Development Workspace/Environment Tips
+- Unless specified otherwise, do NOT attempt to run any command which requires open network communication. Your Dev environment is sandboxed. No harm will come from trying but you will waste your effort. If a network connection fails, report the exact URL clearly in your task summary.
+- When using grep or other commands to find an option that begins with dashes, wrap the text in single quotes : `'\--option'`
+- Use 'sed' or perl for file changes - there are no other editors. Be aware of potential issues with quotes.
+
+### When debugging an issue, diagnosing a problem, proposing a fix
+- Keep explanations of issues to a minimium.
+- Refer to lines of code rather than reproducing code blocks.
+
+Do not run a test script; there are no valid tests in this package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,6 @@
 
 This repository contains a VSCode extension for remote development with DroidScript. See [how-it-works.md](./how-it-works.md) for full architectural details.
 
-## User-provided custom instructions
-- Follow any additional instructions provided directly by the user in task messages.
-
-## Codex Task Management
-
-### Vocabulary
-
-#### All code
-- The term "funcName()" is intended to disambiguate a function name from common terms. For example, "init()" or "the init() function" is used rather than "the init function", as the latter might be interpreted as any initialization function while the former is explicit about the function name.
-
-#### PHP
-- Various terms are used in instructions and in code comments, which are not found in code itself:
-- A reference to "SomeName::functionName" requires a lookup of `class SomeName` and `function functionName`. In many cases `class SomeName` will be found in a "somename.php" or "some-name.php" file, in WordPress\wp-content\plugins\nevenuti\src or a related subfolder.
-
 ### Coding Conventions
 
 #### All code
@@ -26,29 +12,20 @@ This repository contains a VSCode extension for remote development with DroidScr
 - Use ESM, ES2022+ for NodeJS v22+ with JSDoc and TSDoc.
 - When diagnosing issues, search for possible issues with NodeJS, TypeScript, or NPM packages which are relevant to the problematic functionality.
 
-#### PHP
-- Use modern PHP 8.4 with PHPDoc, integrating with the WordPress 6.8+ API.
-- Use classes or traits to keep files and functions small and modular.
-- When diagnosing issues, search for related notes and nuances in the WordPress Codex, the WordPress core tracker, and the WordPress Gutenberg tracker.
-
 ### README.md
 - The README.md file is not a changelog. README.md describes the project.
-- Do not look in README.md for guidance on how to proceed with your task.
+- Do not look in README.md for guidance on how to proceed with your task. Do look to the game to understand the user/developer understanding of the project.
 - Update README.md as required with new information about the existence of new features and how to use them.
 
 ### Git
 - When creating a new branch always use a meaningful branch name that describes the task - don't use any text like "suggested-change" as part of the branch name or pull request text.
 
-### Special Task Instructions
-- If the user task message requests processing of a suggested change, open `SuggestedChanges.md` if it exists, process an Open item, and on successful completion move it to the Completed section.
-
 ### Development Workspace/Environment Tips
-- Unless specified otherwise, do NOT attempt to run any command which requires open network communication. Your Dev environment is sandboxed. No harm will come from trying but you will waste your effort. If a network connection fails, report the exact URL clearly in your task summary.
+- If a network connection fails, report the exact URL clearly in your task summary.
 - When using grep or other commands to find an option that begins with dashes, wrap the text in single quotes : `'\--option'`
 - Use 'sed' or perl for file changes - there are no other editors. Be aware of potential issues with quotes.
 
 ### When debugging an issue, diagnosing a problem, proposing a fix
-- Keep explanations of issues to a minimium.
 - Refer to lines of code rather than reproducing code blocks.
 
 Do not run a test script; there are no valid tests in this package.

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -1,0 +1,68 @@
+# How It Works
+
+This document explains the runtime flow of the DroidScript VSCode extension and how it manages device connections, projects, and developer tooling.
+
+## Installation and Activation
+- The extension activates when a workspace contains a `.dsproj` file, as defined in `package.json`.
+- `extension.js` exports `activate()` which registers commands and providers, creates tree views for projects, docs, and samples, prepares the workspace, and ensures bundled assets are extracted.
+- Tree views implemented by `ProjectsTreeView.js`, `DocsTreeView.js`, and `SamplesTreeView.js`.
+
+## Extension Enablement
+- `activate()` registers commands through a local `subscribe` helper. Commands range from connecting to a device, synchronizing files, running or stopping apps, to project management actions.
+- Command implementations live in `src/commands/` such as `connect-to-droidscript.js` and `load-files.js`.
+- Providers for completion items, hover information, signature help, and code actions are registered for JavaScript.
+- Status bar items and tree views are established to interact with projects and documentation.
+
+## Connecting to a Device
+1. Users trigger the `droidscript-code.connect` command.
+2. `connect-to-droidscript.js` prompts for the device IP and, if necessary, a password.
+3. The module fetches server info using `dsclient.js`. On failure, retry or re-entry prompts are shown. On success, the supplied callback (the debug server’s start function) runs.
+4. The callback initializes the WebSocket defined in `src/websocket.js`. `wsOnOpen()` marks the extension as connected, starts keep‑alive pings, and exposes a log channel for device output.
+5. If connection fails, the progress message indicates failure and the user is offered options to retry or re‑enter the IP address.
+6. `websocket.js` also defines `wsOnError` and `wsOnClose` to handle failures and cleanup.
+
+### Device UI and Assets
+- On first activation or when versions change, `extractAssets()` wipes and recreates `~/.droidscript`, populating it with bundled definitions.
+- After a successful connection, `onDebugServerStart()` invokes `downloadDefinitions()` to pull `.d.ts` API files from the device into `~/.droidscript/definitions/ts`.
+- Sample programs fetched from the device are stored under `~/.droidscript/samples` when opened.
+
+### Connection Failure and Success
+- When server info cannot be fetched or login fails, the user is notified and prompted to retry or adjust IP/password.
+- When the WebSocket opens, `onDebugServerStart()` refreshes project and sample trees, checks for unsaved changes, and displays status bar controls.
+
+## Disconnection
+- A WebSocket close triggers `wsOnClose()`, which resets the `CONNECTED` flag and calls `onDebugServerStop()`.
+- `onDebugServerStop()` hides status items, clears the current project, refreshes views, and prompts the user to reconnect.
+
+## Opening a Project for Local Development
+1. Selecting a project in the sidebar runs `openProject()`.
+2. The extension checks `dsconfig.json` for an existing local copy; otherwise the user chooses a folder.
+3. The project entry is saved to `dsconfig.json` and `openProjectFolder()` is called.
+4. `openProjectFolder()` adds the folder to the VSCode workspace, creates a `.dsproj` file if missing, sets the current project name, and optionally syncs files from the device.
+
+### Pulling a Project from the Device
+- `openProject()` calls `openProjectFolder(proj, "dnlAll")` to force a full download when the project is new.
+- `loadFiles()` prompts for the sync action. For downloads, `getAllFiles()` lists remote files via `indexFolder()`, creates needed directories, and writes each file locally using `writeFile()`.
+- Downloaded files live inside the chosen project folder, which becomes part of the current workspace.
+
+### Syncing and File Events
+- File watchers (`onDidSaveTextDocument`, `onCreateFile`, `onDeleteFile`, `onRenameFile`) queue operations. When connected, pending actions upload, delete, or rename files on the device via `dsclient` functions.
+
+## Configuration Files
+- `dsconfig.json` in the user’s home directory stores server settings and local project metadata.
+- Managed by `src/local-data.js` which reads and writes `dsconfig.json`.
+- Project-specific configuration such as `jsconfig.json` and `.vscode/settings.json` can be generated via commands to enable typing and auto-formatting.
+
+## Providers and Documentation
+- `completionItemProvider.js` (completion items), `hoverProvider.js` (hover info), `signatureProvider.js` (signature help), and `codeActionProvider.js` (code actions) draw from JSON under `completions/`.
+- Hover flow: when the user hovers over a symbol, `hoverProvider` determines the scope and method name, finds a match in `scopesJson`, and returns Markdown with signatures and documentation.
+
+## Commands and Keyboard Shortcuts
+- Default keybindings map `Alt+R` to `droidscript-code.runApp` and `Alt+S` to `droidscript-code.stop`. All registered commands can have custom keybindings assigned by the user.
+- Declared in `package.json` under `contributes.keybindings`; users may rebind any `droidscript-code.*` command.
+- A wide array of commands is exposed, including project management, execution control, file synchronization, and documentation access.
+
+## Potential Areas for Attention
+- `extractAssets()` deletes the entire `.droidscript` directory before recreating it; misconfiguration could remove user files.
+- Error handling around network operations relies on generic messages; more detailed reporting might help debugging.
+

--- a/project-notes.md
+++ b/project-notes.md
@@ -1,0 +1,63 @@
+# Project Notes
+
+## Overview
+- VSCode extension allowing remote development with DroidScript.
+- Entry point: `extension.js`.
+- Uses WebSocket for device communication and HTTP requests for file operations.
+
+## Activation & Initialization
+- `activate()` registers commands and providers, sets up tree views, prepares workspace, extracts assets when version or folder changes.
+- Tree views implemented by `ProjectsTreeView.js`, `DocsTreeView.js`, and `SamplesTreeView.js` create sidebar panels.
+- Activation event in `package.json` triggers when workspace contains `.dsproj` file.
+
+## Commands
+- Commands registered via `subscribe` helper in `activate()`.
+- Command implementations live in `src/commands/` (e.g., `connect-to-droidscript.js`, `load-files.js`).
+- Key commands: connect, disconnect, loadFiles (sync), extractAssets, run/stop app, open project, open docs, and more.
+- Commands defined in `package.json` to allow user keybindings.
+
+## Connection Flow
+- `connectToDroidScript()` prompts for IP and password, retrieves server info via `dsclient`.
+- On success, invokes callback (`dbgServ.start`) to open WebSocket.
+- `websocket.js` handles connection, sets `CONNECTED`, logs messages, maintain keep-alive, and calls back to extension.
+
+## After Connection
+- `onDebugServerStart()` downloads type definition files, refreshes tree views, checks unsaved changes, shows status bar items, and opens current project if set.
+- Type definitions stored under `~/.droidscript/definitions`.
+
+## Disconnect
+- `wsOnClose()` marks `CONNECTED` false and triggers `onDebugServerStop()`.
+- `onDebugServerStop()` hides status bar items, clears project name, refreshes views, and prompts user to reconnect.
+
+## Device UI & Assets
+- `extractAssets()` clears and recreates local `.droidscript` folders, copying bundled definitions.
+- `downloadDefinitions()` fetches `.d.ts` files from device or remote docs into `~/.droidscript/definitions/ts`.
+- Sample programs fetched from the device are stored under `~/.droidscript/samples`.
+
+## Local Projects
+- `openProject()` decides project location, updates config, and calls `openProjectFolder()`.
+- `openProjectFolder()` adds folder to workspace, creates `.dsproj`, opens main file, and optionally syncs files.
+- `loadFiles()` / `getAllFiles()` manage syncing between device and local project based on selected action (download/upload/update). Uses `indexFolder()` to list remote/local files, `writeFile()` and `createFolder()` to write locally, and `uploadFile()` to push changes.
+
+## File Watching
+- Workspace file events (`onDidSaveTextDocument`, `onCreateFile`, `onDeleteFile`, `onRenameFile`) queue operations to sync with device when connected.
+
+## Configuration
+- `src/local-data.js` reads/writes `dsconfig.json` in user home. Stores server IP, port, and list of local projects.
+
+## Providers
+- Completion, hover, signature help, and code action providers registered for JavaScript.
+- Implemented in `src/providers/` (`completionItemProvider.js`, `hoverProvider.js`, `signatureProvider.js`, `codeActionProvider.js`).
+- Providers read data from `completions/*.json` for API docs and suggestions.
+
+## Keyboard Shortcuts
+- Default keybindings: `Alt+R` for run (`runApp`) and `Alt+S` for stop (`stop`). Others can be assigned to any `droidscript-code.*` command via user settings.
+- Declared in `package.json` under `contributes.keybindings`; users may bind other commands.
+
+## Mouse-over Help
+- `hoverProvider` (in `src/providers/hoverProvider.js`) receives VSCode hover events, inspects the word and scope, matches entries in `scopesJson`, and returns Markdown from `completions/*.json`.
+
+## Potential Issues
+- Handling of undefined or failed responses may need more granular error messages.
+- `extractAssets` removes entire `.droidscript` folder, which could delete user data if misconfigured.
+


### PR DESCRIPTION
## Summary
- merge duplicate project notes and how-it-works content to retain missing details
- document tree views, command modules, sample storage, provider files, and keybinding configuration
- add AGENTS.md with coding guidelines and note to skip tests

## Testing
- `npm test` *(skipped: no valid tests per AGENTS.md)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ccab85ac8332a74dcfe753e08be7