### PR TITLE
feat: auto reconnect on unexpected drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Unlike other development tools which take hours to install and eat up gigabytes 
 - A dropdown appears where you can pick or type an **"IP Address"**.
  - Up to 10 recent IP:port endpoints are remembered and cycled through before prompting again. While cycling, the status bar shows `Trying host:port`; click this text to stop and open the dropdown immediately.
  - If you omit the `:port`, the extension assumes `:8088` or the last used port. Selecting or typing an address attempts only that endpoint and returns to the dropdown if it fails.
- - A **"Password"** prompt follows when required.
+- A **"Password"** prompt follows when required.
+- By default the extension automatically retries connection attempts when the server disconnects unexpectedly. This behaviour
+  can be disabled by setting `"droidscript-code.autoReconnect": false` in your VS Code settings.
 
 ## How to open an app?
 

--- a/extension.js
+++ b/extension.js
@@ -47,6 +47,10 @@ let samplesTreeDataProvider;
 /** @type {ReturnType<debugServer>} */
 let dbgServ;
 
+// Flag to track user-initiated disconnects so auto-reconnect only triggers on
+// unexpected drops.
+let manualDisconnect = false;
+
 /** @type {vscode.StatusBarItem?} */
 let syncButton;
 /** @type {vscode.StatusBarItem?} */
@@ -75,7 +79,10 @@ async function activate(context) {
     }
     subscribe("connect", () => connectToDroidScript(dbgServ.start, setConnectionMessage));
     subscribe("cancelConnect", connectToDroidScript.cancel);
-    subscribe("disconnect", dbgServ.stop);
+    subscribe("disconnect", () => {
+        manualDisconnect = true;
+        dbgServ.stop();
+    });
     subscribe("loadFiles", loadFiles);
     subscribe("extractAssets", extractAssets);
     subscribe("stopApp", stop);
@@ -168,6 +175,7 @@ async function activate(context) {
 
 // This method is called when extension is deactivated
 function deactivate() {
+    manualDisconnect = true;
     dbgServ.stop();
     vscode.commands.executeCommand('livePreview.end');
 }
@@ -673,6 +681,8 @@ async function deleteAppDialog(item) {
     projectsTreeDataProvider.refresh();
 
     if (appName == PROJECT) {
+        // Deleting the active project severs the current session.
+        manualDisconnect = true;
         dbgServ.stop();
         setProjectName();
     }
@@ -854,8 +864,15 @@ async function onDebugServerStop() {
     // pluginsTreeDataProvider.refresh();
     samplesTreeDataProvider.refresh();
     projectsTreeDataProvider.refresh();
-    const selection = await vscode.window.showWarningMessage("DroidScript disconnected.", "Reconnect");
-    if (selection === "Reconnect") vscode.commands.executeCommand("droidscript-code.connect");
+    const autoReconnect = vscode.workspace.getConfiguration('droidscript-code').get('autoReconnect', true);
+    if (!manualDisconnect && autoReconnect) {
+        // Mirror the manual Reconnect path by cycling through known endpoints.
+        vscode.commands.executeCommand("droidscript-code.connect");
+    } else if (!manualDisconnect) {
+        const selection = await vscode.window.showWarningMessage("DroidScript disconnected.", "Reconnect");
+        if (selection === "Reconnect") vscode.commands.executeCommand("droidscript-code.connect");
+    }
+    manualDisconnect = false;
 }
 
 // documentations

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -12,7 +12,7 @@
 - When the connection comes up, `downloadDefinitions()` copies `.d.ts` files from the device into `~/.droidscript/definitions/ts` so UI metadata is cached locally【F:extension.js†L777-L795】.
 
 ## Disconnect behavior
-- When the WebSocket closes, `onDebugServerStop()` hides status‑bar items, clears the current project name, refreshes tree views, and prompts the user to reconnect【F:extension.js†L832-L840】.
+  - When the WebSocket closes, `onDebugServerStop()` hides status‑bar items, clears the current project name, refreshes tree views, and either automatically reconnects or prompts the user based on `droidscript-code.autoReconnect`【F:extension.js†L861-L875】.
 - Manual disconnects call `terminate()` rather than a normal WebSocket close because the DroidScript server replies with the reserved status code `1005`, which `ws` treats as a `RangeError`.
 
 ## Opening a device project locally

--- a/package.json
+++ b/package.json
@@ -18,6 +18,16 @@
   ],
   "main": "./extension.js",
   "contributes": {
+    "configuration": {
+      "title": "DroidScript",
+      "properties": {
+        "droidscript-code.autoReconnect": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically reconnect after an unexpected disconnect."
+        }
+      }
+    },
     "keybindings": [
       {
         "command": "droidscript-code.runApp",

--- a/project-notes.md
+++ b/project-notes.md
@@ -34,7 +34,7 @@
 - `downloadDefinitions()` retrieves `.d.ts` files from the device into `~/.droidscript/definitions/ts` so documentation and UI metadata are cached locally.
 
 ## Disconnect behavior
-- `wsOnClose` marks `CONNECTED` false, stops the keep‑alive timer, and triggers `onDebugServerStop()` to hide status bar items, clear the current project, refresh tree views, and prompt for reconnection.
+  - `wsOnClose` marks `CONNECTED` false, stops the keep‑alive timer, and triggers `onDebugServerStop()` to hide status bar items, clear the current project, refresh tree views, and either cycle through saved endpoints or show a reconnect prompt based on the `droidscript-code.autoReconnect` setting.
 - Manual disconnects call `terminate()` instead of a normal WebSocket close because the DroidScript server sends an invalid status code (1005) during the closing handshake, which otherwise triggers a `RangeError` in the `ws` library.
 
 ## Mouse-over help


### PR DESCRIPTION
## Summary
- add configurable auto-reconnect mechanism
- document autoReconnect setting in manifest and README

## Testing
- `node --check extension.js`


------
https://chatgpt.com/codex/tasks/task_e_68c226ffac9c833299be4a7209812b1b