### PR TITLE
Add command to select DroidScript device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Notable releases.
 
 ### Version 0.3.6 (Unreleased)
+- Added `DroidScript: Select Device` command to choose stored IP:port endpoints.
 - Remember successful connections and automatically cycle through stored IP:Port pairs on reconnect
 - Fixed error from invalid WS status code 1005 from DS on disconnect.
 - Removed debug line causing error log and stray number output in log.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Unlike other development tools which take hours to install and eat up gigabytes 
 - A **"Password"** prompt follows when required.
 - By default the extension automatically retries connection attempts when the server disconnects unexpectedly. This behaviour
   can be disabled by setting `"droidscript-code.autoReconnect": false` in your VS Code settings.
+- Use `DroidScript: Select Device` from the Command Palette to choose or enter an endpoint without connecting.
+
 
 ## How to open an app?
 

--- a/extension.js
+++ b/extension.js
@@ -19,6 +19,7 @@ const createNewApp = require("./src/commands/create-app");
 const deleteApp = require("./src/commands/delete-app");
 const revealExplorer = require("./src/commands/revealExplorer");
 const renameApp = require("./src/commands/rename-app");
+const selectDevice = require("./src/commands/select-device");
 const smartDeclare = require('./src/commands/smartDeclare');
 
 const completionItemProvider = require("./src/providers/completionItemProvider");
@@ -79,6 +80,7 @@ async function activate(context) {
     }
     subscribe("connect", () => connectToDroidScript(dbgServ.start, setConnectionMessage));
     subscribe("cancelConnect", connectToDroidScript.cancel);
+    subscribe("selectDevice", selectDevice);
     subscribe("disconnect", () => {
         manualDisconnect = true;
         dbgServ.stop();

--- a/package.json
+++ b/package.json
@@ -159,6 +159,10 @@
       {
         "command": "droidscript-code.disconnect",
         "title": "DroidScript: Disconnect IDE"
+      },
+      {
+        "command": "droidscript-code.selectDevice",
+        "title": "DroidScript: Select Device"
       }
     ],
     "menus": {

--- a/src/commands/select-device.js
+++ b/src/commands/select-device.js
@@ -1,0 +1,43 @@
+const vscode = require('vscode');
+const localData = require('../local-data');
+
+/**
+ * Show QuickPick to choose a stored DroidScript endpoint.
+ */
+module.exports = async function selectDevice() {
+    // Load cached configuration to access saved endpoints.
+    const config = localData.load();
+
+    const quickPick = vscode.window.createQuickPick();
+    quickPick.placeholder = 'Enter IP Address: 192.168.254.112:8088';
+    quickPick.ignoreFocusOut = true;
+    // Pre-populate with recently used endpoints.
+    quickPick.items = config.serverIPs.map(ip => ({ label: ip }));
+
+    const endpoint = await new Promise(resolve => {
+        quickPick.onDidAccept(() => {
+            const value = quickPick.selectedItems[0]?.label || quickPick.value;
+            quickPick.hide();
+            resolve(value);
+        });
+        quickPick.onDidHide(() => {
+            quickPick.dispose();
+            resolve(undefined);
+        });
+        quickPick.show();
+    });
+
+    if (!endpoint) return;
+    // Normalize the chosen endpoint and persist it.
+    const value = endpoint.trim().replace(/^https?:\/\//, '');
+    const [host, portPart] = value.split(':');
+    const port = portPart || config.PORT || '8088';
+    const ep = `${host}:${port}`;
+
+    config.serverIP = `http://${ep}`;
+    config.PORT = port;
+    config.serverIPs = [ep, ...config.serverIPs.filter(h => h !== ep)].slice(0, 10);
+    localData.save(config);
+
+    vscode.window.showInformationMessage(`Selected DroidScript device ${ep}`);
+};


### PR DESCRIPTION
## Summary
- add `DroidScript: Select Device` command to pick stored IP:port endpoints
- expose command in extension activation and VS Code contribution
- document device selection command and update changelog

## Testing
- No tests available for this repository

------
https://chatgpt.com/codex/tasks/task_e_68c22e3cf12c8332884de6a1079b59c2