### PR TITLE
Improve device selection on connection failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Unlike other development tools which take hours to install and eat up gigabytes 
 - Open DroidScript app on your phone and press the WiFi icon to start the DS WiFi IDE server. You should be able to see the IP Address on the popup message.
 - Click the **"Connect"** button in the Projects view or in the Samples view. You can also click the **"Connect to DroidScript"** button in the bottom right corner.
 - A popup will be displayed where to enter **"IP Address"** and **"Password"** if necessary.
+- If the connection fails, a panel will ask you to ensure the DS App is running and that the IP:Port endpoint is correct. The DroidScript Select Device quick pick will open so you can choose an existing endpoint or enter a new one.
 
 ## How to open an app?
 

--- a/src/commands/connect-to-droidscript.js
+++ b/src/commands/connect-to-droidscript.js
@@ -52,11 +52,11 @@ async function getServerInfo() {
         let info = await ext.getServerInfo();
         if (!info || info.status !== "ok") {
             prog.report({ message: "Failed" });
-            vscode.window.showErrorMessage("Make sure the DS App is running and IP Address is correct.", "Retry", "Re-enter IP Address")
-                .then(res => {
-                    if (res === "Retry") getServerInfo();
-                    else if (res === "Re-enter IP Address") showIpPopup();
-                });
+            await vscode.window.showErrorMessage(
+                "Make sure the DS App is running and IP:Port endpoint is correct. Select endpoint from above or enter a new endpoint."
+                // , "Retry", "Re-enter IP Address"
+            );
+            vscode.commands.executeCommand("droidscript-code.selectDevice");
             return;
         }
 


### PR DESCRIPTION
## Summary
- Show clearer guidance when connection to DroidScript fails
- Automatically open the Select Device quick pick for choosing a new endpoint
- Document fallback endpoint selection in README

## Testing
- `npm test` (fails: Parsing error in src/local-data.js)
- `npm run lint` (fails: Parsing error in src/local-data.js)

------
https://chatgpt.com/codex/tasks/task_e_68c23093ff2c8332bde3633c42e753a2