### PR TITLE
Ensure new folders sync to DroidScript device

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -572,10 +572,15 @@ async function onCreateFile(e) {
           "An error occured while writing the file in DroidScript."
         );
     } else if (stats.isDirectory()) {
-      // folder
-      // const code = `app.MakeFolder("${filePath}")`;
-      // response = await ext.execute("usr", code);
-      // console.log( response );
+      // Create the corresponding directory on the device
+      const response = await ext.execute(
+        "usr",
+        `app.MakeFolder("${dsFile}")`
+      );
+      if (!response || response.status !== 200)
+        vscode.window.showErrorMessage(
+          "An error occured while creating the folder in DroidScript."
+        );
     }
   });
 }


### PR DESCRIPTION
## Summary
- Create remote directories when workspace folders are added
- Show an error message if remote folder creation fails

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c4a4c0da8883328504470c9069c96b